### PR TITLE
[Fix] 아군 근접유닛 저지 판정 수정

### DIFF
--- a/ZooDOS/Assets/02.Scripts/Unit/PlayerUnit/PlayerUnit.cs
+++ b/ZooDOS/Assets/02.Scripts/Unit/PlayerUnit/PlayerUnit.cs
@@ -20,8 +20,13 @@ public class PlayerUnit : Unit
 
     PlayerUnitBasicAttack _basicAttack;
 
+
+    public TileType TileType => _tileType;
+
     void Update()
     {
+        _basicAttack.AddTarget();
+
         // 공격 딜레이
         _leftAttackTime += Time.deltaTime;
 
@@ -129,6 +134,17 @@ public class PlayerUnit : Unit
     
     public override void OnDeath()
     {
+        if(TileType == TileType.Ground)
+        {
+            List<Unit> targets = _basicAttack.GetTargets();
+            foreach(Unit target in targets)
+            {
+                EnemyUnit enemy = target as EnemyUnit;
+                enemy.Unblock();
+            }
+
+        }
+
         Die?.Invoke(this);
         gameObject.SetActive(false);
     }

--- a/ZooDOS/Assets/04.ScriptableObjects/PlayerUnit/Defender.asset
+++ b/ZooDOS/Assets/04.ScriptableObjects/PlayerUnit/Defender.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   Atk: 0
   AtkSpeed: 2
   ProjectileSpeed: 1
-  ResistCapacity: 0
+  ResistCapacity: 3
   PlaceCost: 3
   ReplaceTime: 0
   BackwardRange: 0

--- a/ZooDOS/Assets/04.ScriptableObjects/PlayerUnit/Medic.asset
+++ b/ZooDOS/Assets/04.ScriptableObjects/PlayerUnit/Medic.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   Atk: 0
   AtkSpeed: 2
   ProjectileSpeed: 1
-  ResistCapacity: 0
+  ResistCapacity: 1
   PlaceCost: 4
   ReplaceTime: 0
   BackwardRange: 1

--- a/ZooDOS/Assets/04.ScriptableObjects/PlayerUnit/Sniper.asset
+++ b/ZooDOS/Assets/04.ScriptableObjects/PlayerUnit/Sniper.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   Atk: 0
   AtkSpeed: 2
   ProjectileSpeed: 1
-  ResistCapacity: 0
+  ResistCapacity: 1
   PlaceCost: 5
   ReplaceTime: 0
   BackwardRange: 0


### PR DESCRIPTION

## 작업 내용
1. 기존에는 공격시에만 적을 탐지하여 저지를 수행하였음 -> 적이 아군의 다음 공격 전에 타일을 지나가면 저지를 못함 -> 적의 탐지 및 저지 판정 주기를 변경

## 공유 사항
적을 저지할 시, 자신의 참조를 파라미터로 전달하도록 함